### PR TITLE
Add "unofficial Bash strict mode" to deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail # make bash quit if something weird happens
 
 export KUBE_NAMESPACE=${ENVIRONMENT}
 export KUBE_SERVER=${KUBE_SERVER}


### PR DESCRIPTION
This commit sets some Bash flags to abort the script if weird things happen.
For example:
- a command fails with a non-zero exit code
- environment variables are undefined