### PR TITLE
HOCS-1999 - Create MPAM_EXPORT_USER role in keycloak

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -160,9 +160,10 @@ spec:
             - --resources=uri=/export/TRO*|roles=DCU_EXPORT_USER
             - --resources=uri=/export/DTEN*|roles=DCU_EXPORT_USER
             - --resources=uri=/export/WCS*|roles=WCS_EXPORT_USER
+            - --resources=uri=/export/MPAM*|roles=MPAM_EXPORT_USER
             - --resources=uri=/export/topics*|roles=DCU_EXPORT_USER
-            - --resources=uri=/export/teams*|roles=DCU_EXPORT_USER,WCS_EXPORT_USER|require-any-role=true
-            - --resources=uri=/export/users*|roles=DCU_EXPORT_USER,WCS_EXPORT_USER|require-any-role=true
+            - --resources=uri=/export/teams*|roles=DCU_EXPORT_USER,WCS_EXPORT_USER,MPAM_EXPORT_USER|require-any-role=true
+            - --resources=uri=/export/users*|roles=DCU_EXPORT_USER,WCS_EXPORT_USER,MPAM_EXPORT_USER|require-any-role=true
             - --verbose
             - --enable-refresh-tokens=true
             - --encryption-key=$(ENCRYPTION_KEY)


### PR DESCRIPTION
- blocking access to /export/MPAM path for users without
MPAM_EXPORT_USER role assigned
- allowing access to extract system users and teams for MPAM_EXPORT_USER