### PR TITLE
HOCS-2097 Autoscale Replicas

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -8,39 +8,40 @@ if [[ -z ${VERSION} ]] ; then
     export VERSION=${IMAGE_VERSION}
 fi
 
+if [[ ${KUBE_NAMESPACE} == *prod ]]
+then
+    export MIN_REPLICAS="2"
+    export MAX_REPLICAS="8"
+else
+    export MIN_REPLICAS="1"
+    export MAX_REPLICAS="2"
+fi
+
 if [[ ${ENVIRONMENT} == "cs-prod" ]] ; then
     echo "deploy ${VERSION} to PROD namespace, using HOCS_AUDIT_CS_PROD drone secret"
     export KUBE_TOKEN=${HOCS_AUDIT_CS_PROD}
-    export REPLICAS="2"
 elif [[ ${ENVIRONMENT} == "wcs-prod" ]] ; then
     echo "deploy ${VERSION} to PROD namespace, using HOCS_AUDIT_WCS_PROD drone secret"
     export KUBE_TOKEN=${HOCS_AUDIT_WCS_PROD}
-    export REPLICAS="2"
 elif [[ ${ENVIRONMENT} == "cs-qa" ]] ; then
     echo "deploy ${VERSION} to QA namespace, using HOCS_AUDIT_CS_QA drone secret"
     export KUBE_TOKEN=${HOCS_AUDIT_CS_QA}
-    export REPLICAS="2"
 elif [[ ${ENVIRONMENT} == "wcs-qa" ]] ; then
     echo "deploy ${VERSION} to QA namespace, using HOCS_AUDIT_WCS_QA drone secret"
     export KUBE_TOKEN=${HOCS_AUDIT_WCS_QA}
-    export REPLICAS="2"
 elif [[ ${ENVIRONMENT} == "cs-demo" ]] ; then
     echo "deploy ${VERSION} to DEMO namespace, using HOCS_AUDIT_CS_DEMO drone secret"
     export KUBE_TOKEN=${HOCS_AUDIT_CS_DEMO}
-    export REPLICAS="1"
 elif [[ ${ENVIRONMENT} == "wcs-demo" ]] ; then
     echo "deploy ${VERSION} to DEMO namespace, using HOCS_AUDIT_WCS_DEMO drone secret"
     export KUBE_TOKEN=${HOCS_AUDIT_WCS_DEMO}
-    export REPLICAS="1"
 elif [[ ${ENVIRONMENT} == "cs-dev" ]] ; then
     echo "deploy ${VERSION} to DEV namespace, using HOCS_AUDIT_CS_DEV drone secret"
     export KUBE_TOKEN=${HOCS_AUDIT_CS_DEV}
-    export REPLICAS="1"
     export DOMAIN="dev.internal.cs"
 elif [[ ${ENVIRONMENT} == "wcs-dev" ]] ; then
     echo "deploy ${VERSION} to DEV namespace, using HOCS_AUDIT_WCS_DEV drone secret"
     export KUBE_TOKEN=${HOCS_AUDIT_WCS_DEV}
-    export REPLICAS="1"
     export DOMAIN="dev.wcs"
 else
     echo "Unable to find environment: ${ENVIRONMENT}"

--- a/kd/autoscale.yaml
+++ b/kd/autoscale.yaml
@@ -5,8 +5,8 @@ metadata:
     app: hocs-audit
   name: hocs-audit
 spec:
-  maxReplicas: 4
-  minReplicas: {{.REPLICAS}}
+  maxReplicas: {{.MAX_REPLICAS}}
+  minReplicas: {{.MIN_REPLICAS}}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     version: {{.VERSION}}
 spec:
-  replicas: {{.REPLICAS}}
+  replicas: {{.MIN_REPLICAS}}
   selector:
     matchLabels:
       name: hocs-audit


### PR DESCRIPTION
Maximum replicas are now specified in the deploy script, with prod and not-prod settings.
Audit in Prod has it's own database, hence the extended max replica value of 8.