### PR TITLE
HOCS-2461 Increase idle timeout

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -147,6 +147,7 @@ spec:
             - --upstream-response-header-timeout={{.PROXY_TIMEOUT}}s
             - --upstream-expect-continue-timeout={{.PROXY_TIMEOUT}}s
             - --upstream-keepalive-timeout={{.PROXY_TIMEOUT}}s
+            - --server-idle-timeout={{.PROXY_TIMEOUT}}s # default 120s
             - --server-read-timeout={{.PROXY_TIMEOUT}}s
             - --server-write-timeout={{.PROXY_TIMEOUT}}s
             - --no-redirects=false


### PR DESCRIPTION
This commit fixes a live support issue wherein reports were timing out
after 120 seconds. We had a similar problem a few weeks ago, wherein
we changed all the 60 second defaults to 300 seconds; we must've missed
this one as it defaults to 120s instead of 60s.

The previous fix was 45c2c2cdbff444dc00736ddb25851b521e3e1288.