### PR TITLE
HOCS-2310 Running custom reports takes too long

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -165,6 +165,7 @@ spec:
             - --resources=uri=/export/topics*|roles=DCU_EXPORT_USER
             - --resources=uri=/export/teams*|roles=DCU_EXPORT_USER,WCS_EXPORT_USER,MPAM_EXPORT_USER|require-any-role=true
             - --resources=uri=/export/users*|roles=DCU_EXPORT_USER,WCS_EXPORT_USER,MPAM_EXPORT_USER|require-any-role=true
+            - --resources=uri=/export/custom/*/refresh|methods=POST|white-listed=true
             - --verbose
             - --enable-refresh-tokens=true
             - --encryption-key=$(ENCRYPTION_KEY)

--- a/kd/refreshDcuAggregatedCasesView.yaml
+++ b/kd/refreshDcuAggregatedCasesView.yaml
@@ -28,7 +28,8 @@ spec:
               command: ["/bin/sh", "-c"]
               args:
                 - >
-                  http_status=$( curl -vk -u ${HOCS_BASICAUTH} -w '%{http_code}'
+                  http_status=$( curl -vk -X POST -u ${HOCS_BASICAUTH} -w '%{http_code}'
+                  -H "X-Auth-Roles: REFRESH_MATERIALISED_VIEW_USER"
                   https://hocs-audit.{{.KUBE_NAMESPACE}}.svc.cluster.local/export/custom/DCU_AGGREGATED_CASES/refresh );
                   if [[ $http_status -eq 200 ]]; then exit 0; else exit 1; fi
           restartPolicy: OnFailure


### PR DESCRIPTION
* Allow access to refresh endpoint through keycloak-proxy
* Pass refresh auth role in curl request