### PR TITLE
HOCS-2310: change cron-job

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -18,12 +18,18 @@ if [[ ${KUBE_NAMESPACE} == *prod ]]
 then
     export MIN_REPLICAS="2"
     export MAX_REPLICAS="8"
+
+    # Specify to run the refresh cron-job at 5:30 every day for prod.
+    export REFRESH_CRON = "30 4 * * *"
     
     export CLUSTER_NAME="acp-prod"
     export KUBE_SERVER=https://kube-api-prod.prod.acp.homeoffice.gov.uk
-else
+else 
     export MIN_REPLICAS="1"
     export MAX_REPLICAS="2"
+
+    # Specify to run the refresh cron-job at 9:00 Mon-Friday for not-prod.
+    export REFRESH_CRON = "0 8 * * 1-5"
 
     export CLUSTER_NAME="acp-notprod"
     export KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk

--- a/kd/refreshDcuAggregatedCasesView.yaml
+++ b/kd/refreshDcuAggregatedCasesView.yaml
@@ -28,7 +28,7 @@ spec:
               command: ["/bin/sh", "-c"]
               args:
                 - >
-                  http_status=$( curl -vk -X POST -u ${HOCS_BASICAUTH} -w '%{http_code}'
+                  http_status=$( curl -vk -X POST -u ${HOCS_BASICAUTH} -w '%{http_code}' -H 'User-Agent: Refresh DCU_AGGREGATED_CASES'
                   https://hocs-audit.{{.KUBE_NAMESPACE}}.svc.cluster.local/audit/export/custom/DCU_AGGREGATED_CASES/refresh );
                   if [[ $http_status -eq 200 ]]; then exit 0; else exit 1; fi
           restartPolicy: OnFailure

--- a/kd/refreshDcuAggregatedCasesView.yaml
+++ b/kd/refreshDcuAggregatedCasesView.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: hocs-refresh-dcu-caseview
 spec:
-  schedule: "0 22 * * 1-5"
+  schedule: {{.REFRESH_CRON}}
   jobTemplate:
     spec:
       backoffLimit: 3
@@ -29,7 +29,6 @@ spec:
               args:
                 - >
                   http_status=$( curl -vk -X POST -u ${HOCS_BASICAUTH} -w '%{http_code}'
-                  -H "X-Auth-Roles: REFRESH_MATERIALISED_VIEW_USER"
-                  https://hocs-audit.{{.KUBE_NAMESPACE}}.svc.cluster.local/export/custom/DCU_AGGREGATED_CASES/refresh );
+                  https://hocs-audit.{{.KUBE_NAMESPACE}}.svc.cluster.local/audit/export/custom/DCU_AGGREGATED_CASES/refresh );
                   if [[ $http_status -eq 200 ]]; then exit 0; else exit 1; fi
           restartPolicy: OnFailure


### PR DESCRIPTION
We have currently just changed the implementation of the cronjob. 
This is now set to run early morning (within system uptime varying by 
system). This change also removes the unnecessary 
role header and changes the curl to accommodate the new endpoint 
url. We have also added a custom user agent header to the curl 
to allow for better identification in the logs.