### PR TITLE
Never restart failed job

### DIFF
--- a/kd/refreshDcuAggregatedCasesView.yaml
+++ b/kd/refreshDcuAggregatedCasesView.yaml
@@ -6,7 +6,7 @@ spec:
   schedule: {{.REFRESH_CRON}}
   jobTemplate:
     spec:
-      backoffLimit: 3
+      backoffLimit: 1
       template:
         metadata:
           labels:
@@ -31,4 +31,4 @@ spec:
                   http_status=$( curl -vk -X POST -u ${HOCS_BASICAUTH} -w '%{http_code}' -H 'User-Agent: Refresh DCU_AGGREGATED_CASES'
                   https://hocs-audit.{{.KUBE_NAMESPACE}}.svc.cluster.local/admin/export/custom/DCU_AGGREGATED_CASES/refresh );
                   if [[ $http_status -eq 200 ]]; then exit 0; else exit 1; fi
-          restartPolicy: OnFailure
+          restartPolicy: Never


### PR DESCRIPTION
The hocs-refresh-dcu-caseview job times out after 5m00s but appears to
go through regardless. This commit prevents the controller from spinning
up additional jobs to fulfil the task if the first job fails, to avoid
several consecutive refreshes, which causes excessive load on the
system.