### PR TITLE
HOCS-2239: specify downscaler annotation

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -21,6 +21,7 @@ then
 
     # Specify to run the refresh cron-job at 5:30 every day for prod.
     export REFRESH_CRON="30 5 * * *"
+    export UPTIME_PERIOD="Mon-Sun 05:00-23:00 Europe/London"
     
     export CLUSTER_NAME="acp-prod"
     export KUBE_SERVER=https://kube-api-prod.prod.acp.homeoffice.gov.uk
@@ -30,6 +31,7 @@ else
 
     # Specify to run the refresh cron-job at 9:00 Mon-Friday for not-prod.
     export REFRESH_CRON="0 9 * * 1-5"
+    export UPTIME_PERIOD="Mon-Fri 08:00-18:00 Europe/London"
 
     export CLUSTER_NAME="acp-notprod"
     export KUBE_SERVER=https://kube-api-notprod.notprod.acp.homeoffice.gov.uk

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: hocs-audit
   labels:
     version: {{.VERSION}}
+  annotations:
+    downscaler/uptime: {{.UPTIME_PERIOD}}
 spec:
   replicas: {{.MIN_REPLICAS}}
   selector:


### PR DESCRIPTION
Presently, when the deployment changes the downscaler annotation 
(that was manually added up to present) gets removed. This causes 
pod to stay up indefinitely, which leads to increased costs and 
potential issues. This change enforced the uptime meta-data 
annotation that enforces this server stays up. This is specified 
differently depending on if we are in prod or notprod.